### PR TITLE
Add back FreeBSD support

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -17,7 +17,12 @@
  */
 
 #include <string.h>
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#define bswap_32 bswap32
+#else
 #include <byteswap.h>
+#endif
 #include "md5.h"
 
 #ifndef HIGHFIRST

--- a/pam_pwdfile.c
+++ b/pam_pwdfile.c
@@ -63,10 +63,24 @@
 #include <syslog.h>
 
 #include <security/pam_appl.h>
+#if defined(HAVE_SECURITY_PAM_EXT_H)
+# include <security/pam_ext.h>
+#elif defined(HAVE_PAM_PAM_EXT_H)
+# include <pam/pam_ext.h>
+#endif
+
+#ifndef HAVE_PAM_VSYSLOG
+#define pam_vsyslog(pamh, priority, fmt, ...) \
+    vsyslog((priority), (fmt), ##__VA_ARGS__)
+#endif /* HAVE_PAM_VSYSLOG */
+
+#ifndef HAVE_PAM_SYSLOG
+#define pam_syslog(pamh, priority, fmt, ...) \
+    syslog((priority), (fmt), ##__VA_ARGS__)
+#endif /* HAVE_PAM_VSYSLOG */
 
 #define PAM_SM_AUTH
 #include <security/pam_modules.h>
-#include <security/pam_ext.h>
 
 #include "md5.h"
 #include "bigcrypt.h"

--- a/pam_pwdfile.c
+++ b/pam_pwdfile.c
@@ -42,7 +42,7 @@
 #define _GNU_SOURCE
 #include <crypt.h>
 #else
-#ifndef _XOPEN_SOURCE
+#if !defined(_XOPEN_SOURCE) && !defined(_BSD_SOURCE)
 #define _XOPEN_SOURCE 700
 #endif
 #ifndef _BSD_SOURCE


### PR DESCRIPTION
The changes since 0.99 were done using Linuxisms.
In consequence, the latest versions can not be compiled under FreeBSD.
These commits fix that.
